### PR TITLE
Set gem server sources in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem 'jekyll'
 gem 'jekyll-paginate'
 gem 'jekyll-compose', group: [:jekyll_plugins]


### PR DESCRIPTION
This should fix the `Could not find gem 'jekyll-xxx' [...]` errors.