### PR TITLE
Try centering pagination

### DIFF
--- a/_includes/styles.scss
+++ b/_includes/styles.scss
@@ -507,3 +507,7 @@ pre {
     padding-left: 0;
   }
 }
+
+.pagination .disabled {
+    opacity: 0;
+}

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@ layout: default
   <nav class="pagination" role="navigation">
     {% if paginator.next_page %}
       <a class="newer-posts" href="/page{{paginator.next_page}}">&larr; Older posts</a>
+    {% else %}
+      <a class="newer-posts disabled">&larr; Older posts</a>
     {% endif %}
     <span class="page-number">Page {{ paginator.page }} of {{ paginator.total_pages }}</span>
     {% if paginator.previous_page %}
@@ -38,6 +40,8 @@ layout: default
       {% else %}
         <a class="older-posts" href="/page{{paginator.previous_page}}">Newer posts &rarr;</a>
       {% endif %}
+    {% else %}
+      <a class="older-posts disabled">Newer posts &rarr;</a>
     {% endif %}
   </nav>
 


### PR DESCRIPTION
In the pagination area. If you are at first page, or last page, text "Page x of y" is not align to the center of page, i.e.

```
       ← Older posts  Page 1 of 3
← Older posts  Page 2 of 3  Newer posts →
       Page 3 of 3  Newer posts →
```

I think it would be more beautify if we could render it in the same position of every page, i.e.

```
← Older posts  Page 1 of 3
← Older posts  Page 2 of 3  Newer posts →
               Page 3 of 3  Newer posts →
```

My pull request will write down `← Older posts` and `Newer posts →` instead of not write it at all, then use CSS opacity to hide it if you shouldn't click on the link (if you're on first or last page).