### PR TITLE
Pagination fix for subpath installations

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,16 +29,16 @@ layout: default
 
   <nav class="pagination" role="navigation">
     {% if paginator.next_page %}
-      <a class="newer-posts" href="/page{{paginator.next_page}}">&larr; Older posts</a>
+      <a class="newer-posts" href="{{ site.baseurl }}/page{{paginator.next_page}}">&larr; Older posts</a>
     {% else %}
       <a class="newer-posts disabled">&larr; Older posts</a>
     {% endif %}
     <span class="page-number">Page {{ paginator.page }} of {{ paginator.total_pages }}</span>
     {% if paginator.previous_page %}
       {% if paginator.page == 2 %}
-        <a class="older-posts" href="/">Newer posts &rarr;</a>
+        <a class="older-posts" href="{{ site.baseurl }}/">Newer posts &rarr;</a>
       {% else %}
-        <a class="older-posts" href="/page{{paginator.previous_page}}">Newer posts &rarr;</a>
+        <a class="older-posts" href="{{ site.baseurl }}/page{{paginator.previous_page}}">Newer posts &rarr;</a>
       {% endif %}
     {% else %}
       <a class="older-posts disabled">Newer posts &rarr;</a>


### PR DESCRIPTION
Installing into an subpath current pagination links did not work correct.
This commit fixed it by adding site baseurl to href.