### PR TITLE
Speed up google fonts load by combining the two requests to one

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,5 @@
 <head>
-  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700' rel='stylesheet' type='text/css'>
-  <link href='https://fonts.googleapis.com/css?family=Lora:400,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700|Lora:400,700' rel='stylesheet' type='text/css'>
   <script async custom-element="amp-youtube" src="https://cdn.ampproject.org/v0/amp-youtube-0.1.js"></script>
   {% comment %}
     <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>


### PR DESCRIPTION
I've tried to improve GTmetrix score using this theme. It turns out combine two web-fonts into one request genuine speedup the load time.

source : https://stackoverflow.com/a/34356311